### PR TITLE
make #include formatting consistent

### DIFF
--- a/src/rasta/headers/rasta_lib.h
+++ b/src/rasta/headers/rasta_lib.h
@@ -6,8 +6,8 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include<rasta_new.h>
-#include<rastahandle.h>
+#include "rasta_new.h"
+#include "rastahandle.h"
 
 // The header, which the user will include later.
 

--- a/src/rasta/headers/rasta_red_multiplexer.h
+++ b/src/rasta/headers/rasta_red_multiplexer.h
@@ -7,10 +7,10 @@ extern "C" {  // only need to export C interface if
 #endif
 
 #include <stdint.h>
-#include <event_system.h>
+#include "event_system.h"
 #include "rastamodule.h"
 #include "rastaredundancy_new.h"
-#include <udp.h>
+#include "udp.h"
 
 /**
  * define struct as type here to allow usage in notification pointers

--- a/src/rasta/headers/rastafactory.h
+++ b/src/rasta/headers/rastafactory.h
@@ -11,7 +11,7 @@ extern "C" {  // only need to export C interface if
 #endif
 
 #include "key_exchange.h"
-#include <logging.h>
+#include "logging.h"
 #include "rastamodule.h"
 #include "rastahashing.h"
 #include <stdint.h>

--- a/src/rasta/headers/rastahandle.h
+++ b/src/rasta/headers/rastahandle.h
@@ -10,8 +10,8 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <mqueue.h>
-#include <rastahashing.h>
+#include "mqueue.h"
+#include "rastahashing.h"
 //TODO: check
 //#include <stdint.h>
 #include "rastafactory.h"

--- a/src/rasta/headers/rastahashing.h
+++ b/src/rasta/headers/rastahashing.h
@@ -1,10 +1,10 @@
 #ifndef RASTA_RASTAHASHING_H
 #define RASTA_RASTAHASHING_H
 
-#include <rastautil.h>
-#include <rastamd4.h>
-#include <rastablake2.h>
-#include <rastasiphash24.h>
+#include "rastautil.h"
+#include "rastamd4.h"
+#include "rastablake2.h"
+#include "rastasiphash24.h"
 
 
 /**

--- a/src/rasta/headers/rastamodule.h
+++ b/src/rasta/headers/rastamodule.h
@@ -13,7 +13,7 @@ extern "C" {  // only need to export C interface if
 #include "rastautil.h"
 #include "rastacrc.h"
 #include <stdint.h>
-#include <rastahashing.h>
+#include "rastahashing.h"
 
 #define RASTA_CHECKSUM_VALID 1
 #define RASTA_CHECKSUM_INVALID 0

--- a/src/rasta/headers/udp.h
+++ b/src/rasta/headers/udp.h
@@ -12,7 +12,7 @@ extern "C" {  // only need to export C interface if
 
 #include <stdint.h>
 #include <netinet/in.h>
-#include <config.h>
+#include "config.h"
 
 #ifdef ENABLE_TLS
 #include <wolfssl/options.h>

--- a/src/sci/headers/sci.h
+++ b/src/sci/headers/sci.h
@@ -6,7 +6,7 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <rastautil.h>
+#include "rastautil.h"
 /**
  * Maximum length of a SCI telegram in bytes
  */

--- a/src/sci/headers/sci_telegram_factory.h
+++ b/src/sci/headers/sci_telegram_factory.h
@@ -6,7 +6,7 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <sci.h>
+#include "sci.h"
 
 /**
  * Message type of a SCI version request

--- a/src/sci/headers/scils.h
+++ b/src/sci/headers/scils.h
@@ -6,10 +6,10 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <sci.h>
-#include <hashmap.h>
-#include <scils_telegram_factory.h>
-#include <rasta_new.h>
+#include "sci.h"
+#include "hashmap.h"
+#include "scils_telegram_factory.h"
+#include "rasta_new.h"
 
 /**
  * define struct as type here to allow usage in notification pointers

--- a/src/sci/headers/scils_telegram_factory.h
+++ b/src/sci/headers/scils_telegram_factory.h
@@ -6,8 +6,8 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <sci.h>
-#include <sci_telegram_factory.h>
+#include "sci.h"
+#include "sci_telegram_factory.h"
 
 /**
  * Message type of a show signal aspect telegram.

--- a/src/sci/headers/scip.h
+++ b/src/sci/headers/scip.h
@@ -7,11 +7,11 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <rastahandle.h>
-#include <hashmap.h>
-#include <sci.h>
-#include <scip_telegram_factory.h>
-#include <rasta_new.h>
+#include "rastahandle.h"
+#include "hashmap.h"
+#include "sci.h"
+#include "scip_telegram_factory.h"
+#include "rasta_new.h"
 
 /**
  * define struct as type here to allow usage in notification pointers

--- a/src/sci/headers/scip_telegram_factory.h
+++ b/src/sci/headers/scip_telegram_factory.h
@@ -6,8 +6,8 @@ extern "C" {  // only need to export C interface if
               // used by C++ source code
 #endif
 
-#include <sci.h>
-#include <sci_telegram_factory.h>
+#include "sci.h"
+#include "sci_telegram_factory.h"
 
 /**
  * Message type of a SCI-P change location command


### PR DESCRIPTION
The formatting of `#include` statements is currently inconsistent. This can interfere with tools such as [bindgen](https://github.com/rust-lang/rust-bindgen). This PR fixes the inconsistent includes.