### PR TITLE
rcat: Fix determination of transport sockets count

### DIFF
--- a/examples/rcat/c/dtls.c
+++ b/examples/rcat/c/dtls.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer)
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
         };
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer)
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
         };
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);

--- a/examples/rcat/c/kex.c
+++ b/examples/rcat/c/kex.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer)
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
         };
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer)
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
         };
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);

--- a/examples/rcat/c/rcat.c
+++ b/examples/rcat/c/rcat.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer)
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
         };
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer)
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
         };
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);


### PR DESCRIPTION
Alternatively, the number could be hard coded like it is done in tls.c.