### PR TITLE
Implement redial for transport channels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(ENABLE_RASTA_TLS "Enable RaSTA over TLS" OFF)
 option(ENABLE_RASTA_OPAQUE "Enable Password-Authenticated Session Key Exchange based on OPAQUE" OFF)
 option(ENABLE_CODE_COVERAGE "Provide command to generate code coverage report" OFF)
 option(ENABLE_STATIC_ANALYSIS "Run cppcheck along with the compiler" OFF)
-option(ENABLE_SLEEP_ON_CONNECT "Sleep for 5 seconds after connecting a transport channel" OFF)
+option(ENABLE_SLEEP_ON_CONNECT "Sleep for 5 seconds after connecting a transport channel" ON)
 
 if(ENABLE_STATIC_ANALYSIS)
     set(CMAKE_C_CPPCHECK "cppcheck" "--enable=performance,information")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(ENABLE_RASTA_TLS "Enable RaSTA over TLS" OFF)
 option(ENABLE_RASTA_OPAQUE "Enable Password-Authenticated Session Key Exchange based on OPAQUE" OFF)
 option(ENABLE_CODE_COVERAGE "Provide command to generate code coverage report" OFF)
 option(ENABLE_STATIC_ANALYSIS "Run cppcheck along with the compiler" OFF)
+option(ENABLE_SLEEP_ON_CONNECT "Sleep for 5 seconds after connecting a transport channel" OFF)
 
 if(ENABLE_STATIC_ANALYSIS)
     set(CMAKE_C_CPPCHECK "cppcheck" "--enable=performance,information")

--- a/examples/mux_stresstest/c/main.c
+++ b/examples/mux_stresstest/c/main.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
         while (1) {
             struct RastaPacket hb = createHeartbeat(SERVER_ID, CLIENT_ID, current_seq, current_seq, current_seq, current_seq, &hashing_context);
             current_seq++;
-            redundancy_mux_send(&mux, hb);
+            redundancy_mux_send(&mux, hb, RASTA_ROLE_CLIENT);
             printf("Sent HB %lu\n", current_seq);
 
             struct RastaPacket received = redundancy_mux_retrieve_all(&mux);
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
             received.sender_id = SERVER_ID;
             received.receiver_id = CLIENT_ID;
 
-            redundancy_mux_send(&mux, received);
+            redundancy_mux_send(&mux, received, RASTA_ROLE_SERVER);
 
             printf("Sent HB %lu back to client\n", received.sequence_number);
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,3 +187,8 @@ if(ENABLE_RASTA_TLS)
     target_link_libraries(${target}_dtls wolfssl)
     target_link_libraries(${target}_tls wolfssl)
 endif(ENABLE_RASTA_TLS)
+
+if(ENABLE_SLEEP_ON_CONNECT)
+    target_compile_definitions(${target}_tcp PUBLIC SLEEP_ON_CONNECT)
+    target_compile_definitions(${target}_tls PUBLIC SLEEP_ON_CONNECT)
+endif(ENABLE_SLEEP_ON_CONNECT)

--- a/src/c/experimental/handlers.c
+++ b/src/c/experimental/handlers.c
@@ -49,7 +49,7 @@ int handle_kex_request(struct rasta_connection *connection, struct RastaPacket *
                                              &connection->kex_state,
                                              &connection->config->kex, connection->logger);
 
-                redundancy_mux_send(connection->redundancy_channel, &response);
+                redundancy_mux_send(connection->redundancy_channel, &response, connection->role);
 
                 // set values according to 5.6.2 [3]
                 connection->sn_r = receivedPacket->sequence_number + 1;
@@ -131,7 +131,7 @@ int handle_kex_response(struct rasta_connection *connection, struct RastaPacket 
                 }
                 response = createKexAuthentication(connection->remote_id, connection->my_id, connection->sn_t, receivedPacket->sequence_number, current_ts(), receivedPacket->timestamp, &connection->redundancy_channel->mux->sr_hashing_context, connection->kex_state.user_auth_server, sizeof(connection->kex_state.user_auth_server), connection->logger);
 
-                redundancy_mux_send(connection->redundancy_channel, &response);
+                redundancy_mux_send(connection->redundancy_channel, &response, connection->role);
 
                 // set values according to 5.6.2 [3]
                 connection->sn_r = receivedPacket->sequence_number + 1;

--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -42,7 +42,7 @@ void send_KexRequest(struct rasta_connection *connection) {
         logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA KEX", "Rekeying at %" PRIu64, get_current_time_ms());
     }
 
-    redundancy_mux_send(connection->redundancy_channel, &hb);
+    redundancy_mux_send(connection->redundancy_channel, &hb, connection->role);
 
     connection->sn_t = connection->sn_t + 1;
 
@@ -212,7 +212,7 @@ int data_send_event(void *carry_data) {
                 logger_log(h->logger, LOG_LEVEL_INFO, "RaSTA send handler", "discarding packet because retransmission queue is full");
             }
 
-            redundancy_mux_send(con->redundancy_channel, &data);
+            redundancy_mux_send(con->redundancy_channel, &data, con->role);
 
             logger_log(h->logger, LOG_LEVEL_DEBUG, "RaSTA send handler", "Sent data packet from queue");
 
@@ -314,7 +314,7 @@ struct rasta_connection *handle_conreq(struct rasta_connection *connection, stru
             logger_log(connection->logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE: ConnectionRequest", "Send Connection Response - waiting for Heartbeat");
 
             // Send connection response immediately (don't go through packet batching)
-            redundancy_mux_send(connection->redundancy_channel, &conresp);
+            redundancy_mux_send(connection->redundancy_channel, &conresp, connection->role);
 
             freeRastaByteArray(&conresp.data);
         } else {
@@ -584,7 +584,7 @@ struct rasta_connection* sr_connect(struct rasta_handle *h, unsigned long id) {
     connection->sn_i = connection->sn_t;
 
     // Send connection request immediately (don't go through packet batching)
-    redundancy_mux_send(connection->redundancy_channel, &conreq);
+    redundancy_mux_send(connection->redundancy_channel, &conreq, connection->role);
 
     // increase sequence number
     connection->sn_t++;

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -370,11 +370,12 @@ int redundancy_mux_connect_channel(rasta_connection *connection, redundancy_mux 
     for (unsigned int i = 0; i < channel->transport_channel_count; i++) {
         // Provided transport channels have to match with local ports configured
         success |= rasta_red_connect_transport_channel(connection, channel, &mux->transport_sockets[i]);
-        // TODO move this behind some option
+#ifdef SLEEP_ON_CONNECT        
         if (success) {
             logger_log(mux->logger, LOG_LEVEL_INFO, "RaSTA RedMux connect", "connection established, sleeping for 5 seconds");
             sleep(5);
         }
+#endif
     }
 
     if (!success) {

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -363,7 +363,7 @@ void redundancy_mux_listen_channels(struct rasta_handle *h, redundancy_mux *mux,
 
 int rasta_red_connect_transport_channel(rasta_connection *h, rasta_redundancy_channel *channel, rasta_transport_socket *transport_socket) {
     rasta_transport_channel *transport_connection = &channel->transport_channels[transport_socket->id];
-    transport_connect(h, transport_socket, transport_connection);
+    transport_connect(transport_socket, transport_connection, h->config->tls);
     return transport_connection->connected;
 }
 

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -273,7 +273,7 @@ rasta_redundancy_channel *redundancy_mux_get_channel(redundancy_mux *mux, unsign
     return NULL;
 }
 
-void redundancy_mux_send(rasta_redundancy_channel *receiver, struct RastaPacket *data) {
+void redundancy_mux_send(rasta_redundancy_channel *receiver, struct RastaPacket *data, rasta_role role) {
     redundancy_mux *mux = receiver->mux;
     logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "sending a data packet to id 0x%lX",
                (long unsigned int)data->receiver_id);
@@ -298,16 +298,19 @@ void redundancy_mux_send(rasta_redundancy_channel *receiver, struct RastaPacket 
         rasta_transport_channel *channel = &receiver->transport_channels[i];
 
         if (!channel->connected) {
-            logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Skipping unconnected channel %d/%d",
-                   i + 1, receiver->transport_channel_count);
             // Attempt to connect (maybe previous attempts were unsuccessful)
-            // TODO: Only if this is a RaSTA client, otherwise return
-            // logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Channel is not connected, re-trying %s:%d",
-            //         channel->ip_address, channel->port);
-            // if (transport_redial(channel) != 0) {
-            //     continue;
-            // }
-            continue;
+            // only a RaSTA client can initiate reconnect
+            if (role == RASTA_ROLE_CLIENT) {
+                logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Channel %d/%d is not connected, re-trying %s:%d", 
+                    i + 1, receiver->transport_channel_count, channel->remote_ip_address, channel->remote_port);
+                if (transport_redial(channel) != 0) {
+                    continue;
+                }
+            } else {
+                logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Skipping unconnected channel %d/%d",
+                i + 1, receiver->transport_channel_count);
+                continue;
+            }
         }
 
         channel->send_callback(mux, data_to_send, channel, i);
@@ -367,6 +370,11 @@ int redundancy_mux_connect_channel(rasta_connection *connection, redundancy_mux 
     for (unsigned int i = 0; i < channel->transport_channel_count; i++) {
         // Provided transport channels have to match with local ports configured
         success |= rasta_red_connect_transport_channel(connection, channel, &mux->transport_sockets[i]);
+        // TODO move this behind some option
+        if (success) {
+            logger_log(mux->logger, LOG_LEVEL_INFO, "RaSTA RedMux connect", "connection established, sleeping for 5 seconds");
+            sleep(5);
+        }
     }
 
     if (!success) {

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -303,9 +303,12 @@ void redundancy_mux_send(rasta_redundancy_channel *receiver, struct RastaPacket 
             if (role == RASTA_ROLE_CLIENT) {
                 logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Channel %d/%d is not connected, re-trying %s:%d", 
                     i + 1, receiver->transport_channel_count, channel->remote_ip_address, channel->remote_port);
-                if (transport_redial(channel) != 0) {
+                rasta_transport_socket *socket = &mux->transport_sockets[channel->id];
+                if (transport_redial(channel, socket) != 0) {
                     continue;
                 }
+                logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Reconnected channel %d/%d",
+                i + 1, receiver->transport_channel_count);
             } else {
                 logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux send", "Skipping unconnected channel %d/%d",
                 i + 1, receiver->transport_channel_count);

--- a/src/c/retransmission/messages.c
+++ b/src/c/retransmission/messages.c
@@ -18,7 +18,7 @@ void sendDisconnectionRequest(struct rasta_connection *connection, rasta_disconn
                                                             connection->sn_t, connection->cs_t,
                                                             cur_timestamp(), connection->ts_r, disconnectionData, &connection->redundancy_channel->mux->sr_hashing_context);
 
-    redundancy_mux_send(connection->redundancy_channel, &discReq);
+    redundancy_mux_send(connection->redundancy_channel, &discReq, connection->role);
 
     freeRastaByteArray(&discReq.data);
 }
@@ -33,7 +33,7 @@ void sendHeartbeat(struct rasta_connection *connection, char reschedule_manually
     struct RastaPacket hb = createHeartbeat(connection->remote_id, connection->my_id, connection->sn_t,
                                             connection->cs_t, cur_timestamp(), connection->ts_r, &connection->redundancy_channel->mux->sr_hashing_context);
 
-    redundancy_mux_send(connection->redundancy_channel, &hb);
+    redundancy_mux_send(connection->redundancy_channel, &hb, connection->role);
 
     connection->sn_t = connection->sn_t + 1;
     if (reschedule_manually) {
@@ -46,7 +46,7 @@ void sendRetransmissionRequest(struct rasta_connection *connection) {
                                                              connection->sn_t, connection->cs_t, cur_timestamp(),
                                                              connection->ts_r, &connection->redundancy_channel->mux->sr_hashing_context);
 
-    redundancy_mux_send(connection->redundancy_channel, &retrreq);
+    redundancy_mux_send(connection->redundancy_channel, &retrreq, connection->role);
 
     connection->sn_t = connection->sn_t + 1;
 }
@@ -56,6 +56,6 @@ void sendRetransmissionResponse(struct rasta_connection *connection) {
                                                                connection->sn_t, connection->cs_t, cur_timestamp(),
                                                                connection->ts_r, &connection->redundancy_channel->mux->sr_hashing_context);
 
-    redundancy_mux_send(connection->redundancy_channel, &retrresp);
+    redundancy_mux_send(connection->redundancy_channel, &retrresp, connection->role);
     connection->sn_t = connection->sn_t + 1;
 }

--- a/src/c/retransmission/safety_retransmission.c
+++ b/src/c/retransmission/safety_retransmission.c
@@ -371,7 +371,7 @@ void sr_retransmit_data(rasta_connection *connection) {
         }
 
         // send packet
-        redundancy_mux_send(connection->redundancy_channel, &data);
+        redundancy_mux_send(connection->redundancy_channel, &data, connection->role);
         logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA retransmission", "retransmitted packet with old sn=%lu",
                    (long unsigned int)old_p.sequence_number);
 

--- a/src/c/transport/dtls.c
+++ b/src/c/transport/dtls.c
@@ -307,9 +307,9 @@ int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta
     return 0;
 }
 
-int transport_redial(rasta_transport_channel *channel) {
+int transport_redial(rasta_transport_channel *channel, rasta_transport_socket *socket) {
     // We can't reconnect when using DTLS
-    UNUSED(channel);
+    UNUSED(channel); UNUSED(socket);
     return -1;
 }
 

--- a/src/c/transport/dtls.c
+++ b/src/c/transport/dtls.c
@@ -287,8 +287,8 @@ void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *soc
     add_fd_event(h->ev_sys, &socket->accept_event, EV_READABLE);
 }
 
-int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta_transport_channel *channel) {
-    UNUSED(h);
+int transport_connect(rasta_transport_socket *socket, rasta_transport_channel *channel, rasta_config_tls tls_config) {
+    UNUSED(tls_config);
 
     // channel->id = socket->id;
     // channel->remote_port = port;

--- a/src/c/transport/dtls.c
+++ b/src/c/transport/dtls.c
@@ -307,6 +307,12 @@ int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta
     return 0;
 }
 
+int transport_redial(rasta_transport_channel *channel) {
+    // We can't reconnect when using DTLS
+    UNUSED(channel);
+    return -1;
+}
+
 void transport_close(rasta_transport_channel *channel) {
     (void)channel;
 }

--- a/src/c/transport/events.c
+++ b/src/c/transport/events.c
@@ -103,14 +103,15 @@ int channel_receive_event(void *carry_data) {
 
     if (len <= 0 && !is_dtls_conn_ready) {
         // Connection is broken
-        // TODO: What about disabling events?
         transport_channel->connected = false;
 
-        // Why should a readable UDP socket return len <= 0?
-        // if (data->socket != NULL) {
-        //     disable_fd_event(&data->socket->receive_event);
-        //     remove_fd_event(data->h->ev_sys, &data->socket->receive_event);
-        // }
+        // Disable receive events so this handler doesn't get called endlessly
+        if (data->socket != NULL) {
+            disable_fd_event(&data->socket->receive_event);
+        }
+        if (data->channel != NULL) {
+            disable_fd_event(&data->channel->receive_event);
+        }
     }
 
     if (len < 0) {

--- a/src/c/transport/tcp.c
+++ b/src/c/transport/tcp.c
@@ -127,7 +127,13 @@ int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket
 }
 
 int transport_redial(rasta_transport_channel* channel) {
-    return tcp_connect(channel);
+    // TODO: just reconnecting does not work!
+    if (tcp_connect(channel) != 0) {
+        return -1;
+    }
+
+    enable_fd_event(&channel->receive_event);
+    return 0;
 }
 
 void transport_close(rasta_transport_channel *channel) {

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -346,13 +346,26 @@ int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket
     return 0;
 }
 
-int transport_redial(rasta_transport_channel* channel) {
-    // TODO: just reconnecting does not work!
+int transport_redial(rasta_transport_channel* channel, rasta_transport_socket *socket) {
+    // create a new socket (closed socket cannot be reused)
+    socket->file_descriptor = bsd_create_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    channel->file_descriptor = socket->file_descriptor;
+
+    // bind new socket to the configured ip/port
+    rasta_handle *h = socket->accept_event_data.h;
+    const rasta_ip_data *ip_data = &h->mux.config->redundancy.connections.data[socket->id];
+    transport_bind(h, socket, ip_data->ip, (uint16_t)ip_data->port);
+
     if (tcp_connect(channel) != 0) {
         return -1;
     }
 
+    socket->receive_event.fd = socket->file_descriptor;
+    socket->accept_event.fd = socket->file_descriptor;
+
+    channel->receive_event.fd = channel->file_descriptor;
     enable_fd_event(&channel->receive_event);
+    
     return 0;
 }
 

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -278,7 +278,7 @@ int transport_accept(rasta_transport_socket *socket, struct sockaddr_in *addr) {
     return fd;
 }
 
-int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket, rasta_transport_channel *channel) {
+int transport_connect(rasta_transport_socket *socket, rasta_transport_channel *channel, rasta_config_tls tls_config) {
     channel->file_descriptor = socket->file_descriptor;
 
     if (tcp_connect(channel) != 0) {
@@ -298,10 +298,10 @@ int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket
         return -1;
     }
 
-    if (h->config->tls.tls_hostname[0]) {
-        int ret = wolfSSL_check_domain_name(channel->ssl, h->config->tls.tls_hostname);
+    if (tls_config.tls_hostname[0]) {
+        int ret = wolfSSL_check_domain_name(channel->ssl, tls_config.tls_hostname);
         if (ret != SSL_SUCCESS) {
-            fprintf(stderr, "Could not add domain name check for domain %s: %d", h->config->tls.tls_hostname, ret);
+            fprintf(stderr, "Could not add domain name check for domain %s: %d", tls_config.tls_hostname, ret);
             return -1;
         }
     } else {
@@ -331,7 +331,7 @@ int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket
         return -1;
     }
 
-    tls_pin_certificate(channel->ssl, h->config->tls.peer_tls_cert_path);
+    tls_pin_certificate(channel->ssl, tls_config.peer_tls_cert_path);
 
     wolfSSL_FreeArrays(channel->ssl);
     set_tls_async(channel->file_descriptor, channel->ssl);
@@ -349,22 +349,18 @@ int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket
 int transport_redial(rasta_transport_channel* channel, rasta_transport_socket *socket) {
     // create a new socket (closed socket cannot be reused)
     socket->file_descriptor = bsd_create_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    channel->file_descriptor = socket->file_descriptor;
 
     // bind new socket to the configured ip/port
     rasta_handle *h = socket->accept_event_data.h;
     const rasta_ip_data *ip_data = &h->mux.config->redundancy.connections.data[socket->id];
     transport_bind(h, socket, ip_data->ip, (uint16_t)ip_data->port);
 
-    if (tcp_connect(channel) != 0) {
+    if (transport_connect(socket, channel, *channel->tls_config) != 0) {
         return -1;
     }
 
     socket->receive_event.fd = socket->file_descriptor;
     socket->accept_event.fd = socket->file_descriptor;
-
-    channel->receive_event.fd = channel->file_descriptor;
-    enable_fd_event(&channel->receive_event);
     
     return 0;
 }

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -347,9 +347,13 @@ int transport_connect(struct rasta_connection *h, rasta_transport_socket *socket
 }
 
 int transport_redial(rasta_transport_channel* channel) {
-    UNUSED(channel);
+    // TODO: just reconnecting does not work!
+    if (tcp_connect(channel) != 0) {
+        return -1;
+    }
+
+    enable_fd_event(&channel->receive_event);
     return 0;
-    // return tcp_connect(channel);
 }
 
 void transport_close(rasta_transport_channel *channel) {

--- a/src/c/transport/transport.h
+++ b/src/c/transport/transport.h
@@ -100,7 +100,7 @@ void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *soc
 void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port);
 void transport_listen(struct rasta_handle *h, rasta_transport_socket *socket);
 int transport_accept(rasta_transport_socket *socket, struct sockaddr_in *addr);
-int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta_transport_channel *channel);
+int transport_connect(rasta_transport_socket *socket, rasta_transport_channel *channel, rasta_config_tls tls_config);
 int transport_redial(rasta_transport_channel *channel, rasta_transport_socket *socket);
 void transport_close(rasta_transport_channel *channel);
 

--- a/src/c/transport/transport.h
+++ b/src/c/transport/transport.h
@@ -95,16 +95,16 @@ typedef struct rasta_transport_socket {
 void send_callback(redundancy_mux *mux, struct RastaByteArray data_to_send, rasta_transport_channel *channel, unsigned int channel_index);
 ssize_t receive_callback(struct receive_event_data *data, unsigned char *buffer, struct sockaddr_in *sender);
 
-void transport_init(struct rasta_handle *h, rasta_transport_channel* channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config);
+void transport_init(struct rasta_handle *h, rasta_transport_channel *channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config);
 void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *socket, int id, const rasta_config_tls *tls_config);
 void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port);
 void transport_listen(struct rasta_handle *h, rasta_transport_socket *socket);
 int transport_accept(rasta_transport_socket *socket, struct sockaddr_in *addr);
 int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta_transport_channel *channel);
-int transport_redial(rasta_transport_channel* channel);
+int transport_redial(rasta_transport_channel *channel);
 void transport_close(rasta_transport_channel *channel);
 
 
 // Protected methods
-void transport_init_base(struct rasta_handle *h, rasta_transport_channel* channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config);
+void transport_init_base(struct rasta_handle *h, rasta_transport_channel *channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config);
 void find_channel_by_ip_address(struct rasta_handle *h, struct sockaddr_in sender, int *red_channel_idx, int *transport_channel_idx);

--- a/src/c/transport/transport.h
+++ b/src/c/transport/transport.h
@@ -101,7 +101,7 @@ void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, cons
 void transport_listen(struct rasta_handle *h, rasta_transport_socket *socket);
 int transport_accept(rasta_transport_socket *socket, struct sockaddr_in *addr);
 int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta_transport_channel *channel);
-int transport_redial(rasta_transport_channel *channel);
+int transport_redial(rasta_transport_channel *channel, rasta_transport_socket *socket);
 void transport_close(rasta_transport_channel *channel);
 
 

--- a/src/c/transport/udp.c
+++ b/src/c/transport/udp.c
@@ -175,6 +175,12 @@ int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta
     return 0;
 }
 
+int transport_redial(rasta_transport_channel *channel) {
+    // We can't reconnect when using UDP
+    UNUSED(channel);
+    return -1;
+}
+
 void transport_close(rasta_transport_channel *channel) {
     (void)channel;
 }

--- a/src/c/transport/udp.c
+++ b/src/c/transport/udp.c
@@ -175,9 +175,9 @@ int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta
     return 0;
 }
 
-int transport_redial(rasta_transport_channel *channel) {
+int transport_redial(rasta_transport_channel *channel, rasta_transport_socket *socket) {
     // We can't reconnect when using UDP
-    UNUSED(channel);
+    UNUSED(channel); UNUSED(socket);
     return -1;
 }
 

--- a/src/c/transport/udp.c
+++ b/src/c/transport/udp.c
@@ -160,8 +160,8 @@ void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *soc
     add_fd_event(h->ev_sys, &socket->receive_event, EV_READABLE);
 }
 
-int transport_connect(rasta_connection *h, rasta_transport_socket *socket, rasta_transport_channel *channel) {
-    UNUSED(h);
+int transport_connect(rasta_transport_socket *socket, rasta_transport_channel *channel, rasta_config_tls tls_config) {
+    UNUSED(tls_config);
 
     enable_fd_event(&socket->receive_event);
 

--- a/src/include/rasta/rasta_red_multiplexer.h
+++ b/src/include/rasta/rasta_red_multiplexer.h
@@ -11,6 +11,7 @@ extern "C" { // only need to export C interface if
 #include <rasta/event_system.h>
 #include <rasta/rastamodule.h>
 #include <rasta/rastaredundancy.h>
+#include <rasta/rastarole.h>
 
 #define UNUSED(x) (void)(x)
 
@@ -170,7 +171,7 @@ void redundancy_mux_close(redundancy_mux *mux);
  */
 rasta_redundancy_channel *redundancy_mux_get_channel(redundancy_mux *mux, unsigned long id);
 
-void redundancy_mux_send(rasta_redundancy_channel *channel, struct RastaPacket *data);
+void redundancy_mux_send(rasta_redundancy_channel *channel, struct RastaPacket *data, rasta_role role);
 
 /**
  * retrieves a message from the queue of the redundancy channel to entity with RaSTA ID @p id.

--- a/src/include/rasta/rastarole.h
+++ b/src/include/rasta/rastarole.h
@@ -1,0 +1,6 @@
+#pragma once
+
+typedef enum {
+    RASTA_ROLE_CLIENT = 0,
+    RASTA_ROLE_SERVER = 1
+} rasta_role;

--- a/src/include/rasta/temp.h
+++ b/src/include/rasta/temp.h
@@ -6,11 +6,7 @@
 #include "logging.h"
 #include "rastafactory.h"
 #include "rastahashing.h"
-
-typedef enum {
-    RASTA_ROLE_CLIENT = 0,
-    RASTA_ROLE_SERVER = 1
-} rasta_role;
+#include "rastarole.h"
 
 /**
  * representation of the connection state in the SR layer

--- a/test/redundancy_test/c/main.c
+++ b/test/redundancy_test/c/main.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
         printf("Sending message to server\n");
         struct RastaPacket data = createConnectionRequest(SERVER_ID, CLIENT_1_ID, 42, 42, 42, "0303", &hashing_context);
 
-        redundancy_mux_send(&mux, data);
+        redundancy_mux_send(&mux, data, RASTA_ROLE_CLIENT);
         printf("Data sent, exiting...\n");
         redundancy_mux_close(&mux);
         printf("Connection closed\n");
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
         // by receiving data from Client 2 the server will detect the transport channels and it's possible to send to
         // Client 2
         struct RastaPacket hello = createConnectionRequest(SERVER_ID, CLIENT_2_ID, 0, 0, 0, "0303", &hashing_context);
-        redundancy_mux_send(&mux, hello);
+        redundancy_mux_send(&mux, hello, RASTA_ROLE_CLIENT);
 
         printf("Done\n");
         printf("Waiting for message from server...\n");
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
         received.sender_id = SERVER_ID;
         received.receiver_id = CLIENT_2_ID;
 
-        redundancy_mux_send(&mux, received);
+        redundancy_mux_send(&mux, received, RASTA_ROLE_SERVER);
         printf("Sent PDU to Client 2\n");
         printf("Closing connection...\n");
 


### PR DESCRIPTION
This closes #28.

Please note: The function signatures of `redundancy_mux_send`, `transport_connect` and `transport_redial` have changed!