### PR TITLE
Build gRPC bridge and Docker images for all transport variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,16 +95,58 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
+    - name: Extract metadata (tags, labels) for Docker (TCP)
+      id: meta_tcp
       uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/rasta_grpc_bridge
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/rasta_grpc_bridge_tcp
 
-    - name: Build and push Docker image
+    - name: Build and push Docker image (TCP)
       uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
       with:
-        file: docker/rasta_grpc_bridge/Dockerfile
+        file: docker/rasta_grpc_bridge_tcp/Dockerfile
         context: .
         push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
+        tags: ${{ steps.meta_tcp.outputs.tags }}
+
+    - name: Extract metadata (tags, labels) for Docker (UDP)
+      id: meta_udp
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/rasta_grpc_bridge_udp
+
+    - name: Build and push Docker image (UDP)
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        file: docker/rasta_grpc_bridge_udp/Dockerfile
+        context: .
+        push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta_udp.outputs.tags }}
+
+    - name: Extract metadata (tags, labels) for Docker (TLS)
+      id: meta_tls
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/rasta_grpc_bridge_tls
+
+    - name: Build and push Docker image (TLS)
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        file: docker/rasta_grpc_bridge_tls/Dockerfile
+        context: .
+        push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta_tls.outputs.tags }}
+
+    - name: Extract metadata (tags, labels) for Docker (DTLS)
+      id: meta_dtls
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/rasta_grpc_bridge_dtls
+
+    - name: Build and push Docker image (DTLS)
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        file: docker/rasta_grpc_bridge_dtls/Dockerfile
+        context: .
+        push: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta_dtls.outputs.tags }}

--- a/docker/rasta_grpc_bridge_dtls/Dockerfile
+++ b/docker/rasta_grpc_bridge_dtls/Dockerfile
@@ -23,6 +23,6 @@ RUN cd /tmp \
 ENV LD_LIBRARY_PATH=/usr/local/lib:.
 
 WORKDIR /app
-COPY build/librasta*.so build/rasta_grpc_bridge ./
+COPY build/librasta_dtls.so build/rasta_grpc_bridge_dtls ./
 
-ENTRYPOINT ["/app/rasta_grpc_bridge"]
+ENTRYPOINT ["/app/rasta_grpc_bridge_dtls"]

--- a/docker/rasta_grpc_bridge_tcp/Dockerfile
+++ b/docker/rasta_grpc_bridge_tcp/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install --no-install-recommends libtool autogen automake autoconf git ca-certificates build-essential cmake
+
+RUN cd /tmp \
+ && git clone --recurse-submodules -b v1.47.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc \
+ && cd grpc \
+ && mkdir -p cmake/build && cd cmake/build \
+ && cmake ../.. -DgRPC_INSTALL=ON \
+ && make -j16 && make install \
+ && cd / && rm -rf /tmp/grpc
+
+RUN cd /tmp \
+ && git clone --recurse-submodules -b v5.2.0-stable --depth 1 --shallow-submodules https://github.com/wolfssl/wolfssl \
+ && cd wolfssl \
+ && ./autogen.sh \
+ && ./configure --enable-dtls --enable-debug --enable-certgen --enable-tls13 CFLAGS="-DHAVE_SECRET_CALLBACK" --enable-opensslextra \
+ && make && make install \
+ && cd / && rm -rf /tmp/wolfssl
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:.
+
+WORKDIR /app
+COPY build/librasta_tcp.so build/rasta_grpc_bridge_tcp ./
+
+ENTRYPOINT ["/app/rasta_grpc_bridge_tcp"]

--- a/docker/rasta_grpc_bridge_tls/Dockerfile
+++ b/docker/rasta_grpc_bridge_tls/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install --no-install-recommends libtool autogen automake autoconf git ca-certificates build-essential cmake
+
+RUN cd /tmp \
+ && git clone --recurse-submodules -b v1.47.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc \
+ && cd grpc \
+ && mkdir -p cmake/build && cd cmake/build \
+ && cmake ../.. -DgRPC_INSTALL=ON \
+ && make -j16 && make install \
+ && cd / && rm -rf /tmp/grpc
+
+RUN cd /tmp \
+ && git clone --recurse-submodules -b v5.2.0-stable --depth 1 --shallow-submodules https://github.com/wolfssl/wolfssl \
+ && cd wolfssl \
+ && ./autogen.sh \
+ && ./configure --enable-dtls --enable-debug --enable-certgen --enable-tls13 CFLAGS="-DHAVE_SECRET_CALLBACK" --enable-opensslextra \
+ && make && make install \
+ && cd / && rm -rf /tmp/wolfssl
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:.
+
+WORKDIR /app
+COPY build/librasta_tls.so build/rasta_grpc_bridge_tls ./
+
+ENTRYPOINT ["/app/rasta_grpc_bridge_tls"]

--- a/docker/rasta_grpc_bridge_udp/Dockerfile
+++ b/docker/rasta_grpc_bridge_udp/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install --no-install-recommends libtool autogen automake autoconf git ca-certificates build-essential cmake
+
+RUN cd /tmp \
+ && git clone --recurse-submodules -b v1.47.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc \
+ && cd grpc \
+ && mkdir -p cmake/build && cd cmake/build \
+ && cmake ../.. -DgRPC_INSTALL=ON \
+ && make -j16 && make install \
+ && cd / && rm -rf /tmp/grpc
+
+RUN cd /tmp \
+ && git clone --recurse-submodules -b v5.2.0-stable --depth 1 --shallow-submodules https://github.com/wolfssl/wolfssl \
+ && cd wolfssl \
+ && ./autogen.sh \
+ && ./configure --enable-dtls --enable-debug --enable-certgen --enable-tls13 CFLAGS="-DHAVE_SECRET_CALLBACK" --enable-opensslextra \
+ && make && make install \
+ && cd / && rm -rf /tmp/wolfssl
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:.
+
+WORKDIR /app
+COPY build/librasta_udp.so build/rasta_grpc_bridge_udp ./
+
+ENTRYPOINT ["/app/rasta_grpc_bridge_udp"]

--- a/examples/rasta_grpc_bridge/CMakeLists.txt
+++ b/examples/rasta_grpc_bridge/CMakeLists.txt
@@ -44,16 +44,24 @@ add_custom_command(
         "${hw_proto}"
       DEPENDS "${hw_proto}")
 
-add_executable(rasta_grpc_bridge
-    cpp/main.cpp
-    ../common/c/configfile.c
-    ../common/c/dictionary.c
-    ${hw_grpc_srcs}
-    ${hw_grpc_hdrs}
-    ${hw_proto_srcs}
-    ${hw_proto_hdrs})
+if(ENABLE_RASTA_TLS)
+    set(RASTA_VARIANTS udp tcp dtls tls)
+else()
+    set(RASTA_VARIANTS udp tcp)
+endif(ENABLE_RASTA_TLS)
 
-set_target_properties(rasta_grpc_bridge PROPERTIES ${DEFAULT_PROJECT_OPTIONS})
-target_compile_options(rasta_grpc_bridge PRIVATE ${DEFAULT_COMPILE_OPTIONS})
-target_link_libraries(rasta_grpc_bridge rasta_tls ${_REFLECTION} ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF})
-target_include_directories(rasta_grpc_bridge PRIVATE ../common/headers PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+foreach(RASTA_VARIANT ${RASTA_VARIANTS})
+    add_executable(rasta_grpc_bridge_${RASTA_VARIANT}
+        cpp/main.cpp
+        ../common/c/configfile.c
+        ../common/c/dictionary.c
+        ${hw_grpc_srcs}
+        ${hw_grpc_hdrs}
+        ${hw_proto_srcs}
+        ${hw_proto_hdrs})
+
+    set_target_properties(rasta_grpc_bridge_${RASTA_VARIANT} PROPERTIES ${DEFAULT_PROJECT_OPTIONS})
+    target_compile_options(rasta_grpc_bridge_${RASTA_VARIANT} PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+    target_link_libraries(rasta_grpc_bridge_${RASTA_VARIANT} rasta_${RASTA_VARIANT} ${_REFLECTION} ${_GRPC_GRPCPP} ${_PROTOBUF_LIBPROTOBUF})
+    target_include_directories(rasta_grpc_bridge_${RASTA_VARIANT} PRIVATE ../common/headers PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+endforeach()


### PR DESCRIPTION
This fixes #33. We now build four executables `rasta_grpc_bridge_PROTOCOL` for udp, tcp, tls, dtls and let the CI create four Docker images of the same name (each of these now has its own Dockerfile).