### PR TITLE
Fix version check

### DIFF
--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -983,10 +983,11 @@ void load_configfile(rasta_config_info *c, struct logger_t *logger, const char *
 
     if (config_accepted_version.type == DICTIONARY_ARRAY) {
         c->accepted_version_count = config_accepted_version.value.array.count;
-        c->accepted_versions = rmalloc(c->accepted_version_count * 4 * sizeof(char));
+        c->accepted_versions = rmalloc(c->accepted_version_count * 5 * sizeof(char));
         for (unsigned int i = 0; i < c->accepted_version_count; ++i) {
             logger_log(logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE_INIT", "Loaded accepted version: %s", config_accepted_version.value.array.data[i].c);
             rmemcpy(c->accepted_versions[i], config_accepted_version.value.array.data[i].c, 4);
+            c->accepted_versions[i][4] = '\0';
         }
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,5 +190,7 @@ endif(ENABLE_RASTA_TLS)
 
 if(ENABLE_SLEEP_ON_CONNECT)
     target_compile_definitions(${target}_tcp PUBLIC SLEEP_ON_CONNECT)
+    if(ENABLE_RASTA_TLS)
     target_compile_definitions(${target}_tls PUBLIC SLEEP_ON_CONNECT)
+    endif(ENABLE_RASTA_TLS)
 endif(ENABLE_SLEEP_ON_CONNECT)

--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -275,9 +275,9 @@ struct rasta_connection *handle_conreq(struct rasta_connection *connection, stru
 
         logger_log(connection->logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE: ConnectionRequest", "Client has version %.4s", connectionData.version);
 
-        if (compare_version(RASTA_VERSION, connectionData.version) == 0 ||
-            compare_version(RASTA_VERSION, connectionData.version) == -1 ||
-            version_accepted(connection->config, connectionData.version)) {
+        if (compare_version(&RASTA_VERSION, &connectionData.version) == 0 ||
+            compare_version(&RASTA_VERSION, &connectionData.version) == -1 ||
+            version_accepted(connection->config, &connectionData.version)) {
 
             logger_log(connection->logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE: ConnectionRequest", "Version accepted");
 
@@ -347,7 +347,7 @@ struct rasta_connection *handle_conresp(struct rasta_connection *con, struct Ras
 
             logger_log(con->logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE: ConnectionResponse", "Client has version %s", connectionData.version);
 
-            if (version_accepted(con->config, connectionData.version)) {
+            if (version_accepted(con->config, &connectionData.version)) {
 
                 logger_log(con->logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE: ConnectionResponse", "Version accepted");
 

--- a/src/c/retransmission/protocol.c
+++ b/src/c/retransmission/protocol.c
@@ -41,21 +41,11 @@ uint32_t bytesToLong2(const unsigned char v[4]) {
  * @param local_version the local version
  * @param remote_version the remote version
  * @return  0 if local_version == remote_version
- *         -1 if local_version < remove_version
+ *         -1 if local_version < remote_version
  *          1 if local_version > remote_version
  */
 int compare_version(const char (*local_version)[5], const char (*remote_version)[5]) {
-    char *tmp;
-    long local = strtol(*local_version, &tmp, 4);
-    long remote = strtol(*remote_version, &tmp, 4);
-
-    if (local == remote) {
-        return 0;
-    } else if (local < remote) {
-        return -1;
-    } else {
-        return 1;
-    }
+    return strncmp(*local_version, *remote_version, 4);
 }
 
 /**

--- a/src/c/retransmission/protocol.c
+++ b/src/c/retransmission/protocol.c
@@ -55,7 +55,6 @@ int compare_version(const char (*local_version)[5], const char (*remote_version)
  */
 int version_accepted(rasta_config_info *config, const char (*version)[5]) {
     for (unsigned int i = 0; i < config->accepted_version_count; ++i) {
-        // const (char[5]) * av = ;
         if (compare_version(&config->accepted_versions[i], version) == 0) {
             // match, version is in accepted version list
             return 1;

--- a/src/c/retransmission/protocol.c
+++ b/src/c/retransmission/protocol.c
@@ -44,10 +44,10 @@ uint32_t bytesToLong2(const unsigned char v[4]) {
  *         -1 if local_version < remove_version
  *          1 if local_version > remote_version
  */
-int compare_version(const char local_version[5], const char remote_version[5]) {
+int compare_version(const char (*local_version)[5], const char (*remote_version)[5]) {
     char *tmp;
-    long local = strtol(local_version, &tmp, 4);
-    long remote = strtol(remote_version, &tmp, 4);
+    long local = strtol(*local_version, &tmp, 4);
+    long remote = strtol(*remote_version, &tmp, 4);
 
     if (local == remote) {
         return 0;
@@ -63,9 +63,10 @@ int compare_version(const char local_version[5], const char remote_version[5]) {
  * @param version the version of the remote
  * @return 1 if the remote version is accepted, else 0
  */
-int version_accepted(rasta_config_info *config, const char version[5]) {
+int version_accepted(rasta_config_info *config, const char (*version)[5]) {
     for (unsigned int i = 0; i < config->accepted_version_count; ++i) {
-        if (compare_version(config->accepted_versions[i], version) == 0) {
+        // const (char[5]) * av = ;
+        if (compare_version(&config->accepted_versions[i], version) == 0) {
             // match, version is in accepted version list
             return 1;
         }

--- a/src/c/retransmission/protocol.h
+++ b/src/c/retransmission/protocol.h
@@ -14,5 +14,5 @@
 
 uint64_t get_current_time_ms();
 
-int compare_version(const char local_version[5], const char remote_version[5]);
-int version_accepted(rasta_config_info *config, const char version[5]);
+int compare_version(const char (*local_version)[5], const char (*remote_version)[5]);
+int version_accepted(rasta_config_info *config, const char (*version)[5]);

--- a/src/include/rasta/config.h
+++ b/src/include/rasta/config.h
@@ -115,7 +115,7 @@ typedef struct rasta_config_info {
     uint32_t initial_sequence_number;
 
     size_t accepted_version_count;
-    char (*accepted_versions)[4];
+    char (*accepted_versions)[5];
 
     /**
      * all values for the sending part


### PR DESCRIPTION
We had inconsistencies about the length of the version string (seen as a byte array). This fixes that and also simplifies the implementation of `compare_version`.