### PR TITLE
Ensure all messages in send queue get sent

### DIFF
--- a/examples/rasta_grpc_bridge/cpp/main.cpp
+++ b/examples/rasta_grpc_bridge/cpp/main.cpp
@@ -64,16 +64,18 @@ void processConnection(std::function<std::thread()> run_thread) {
 
         RastaByteArray *msg = nullptr;
 
-        {
-            std::lock_guard<std::mutex> guard(s_fifo_mutex);
-            msg = reinterpret_cast<RastaByteArray *>(fifo_pop(s_message_fifo));
-        }
+        do {
+            {
+                std::lock_guard<std::mutex> guard(s_fifo_mutex);
+                msg = reinterpret_cast<RastaByteArray *>(fifo_pop(s_message_fifo));
+            }
 
-        if (msg != nullptr) {
-            rasta_send(s_rc, s_connection,  msg->bytes, msg->length);
+            if (msg != nullptr) {
+                rasta_send(s_rc, s_connection,  msg->bytes, msg->length);
 
-            freeRastaByteArray(msg);
-        }
+                freeRastaByteArray(msg);
+            }
+        } while (msg != nullptr);
 
         return 0;
     };

--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -227,8 +227,10 @@ int data_send_event(void *carry_data) {
         }
     }
 
-    // Disable this event until new data arrives
-    disable_timed_event(&h->send_event);
+    if (sr_send_queue_item_count(con) == 0) {
+        // Disable this event until new data arrives
+        disable_timed_event(&h->send_event);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Context: for sending packets in batches (n max packet), there is a `send_event` that fires in a hardcoded interval. We also directly call the event once we have n max packet entries in the send queue.

There was a problem with bursts of `rasta_send` calls, not all packets were sent in the following scenario:

 - `rasta_send` is called many times until the retransmission queue is full (this holds packets that were not yet confirmed as received by the other end of the connection)
 - In `data_send_event`, sending new messages is deferred because of that
 - The `send_event` was disabled by `data_send_event`, so the event was never called again, thus the pending messages from the send queue were never sent
 - This PR changes this behavior and leaves the `send_event` active unless the send queue is empty

A further optimization could be to directly re-evaluate the send_event handler once new packets have been confirmed and taken out of the retransmission queue.