### PR TITLE
gRPC bridge: replace eventfd() by pipe() for POSIX compatibility

### DIFF
--- a/examples/rasta_grpc_bridge/cpp/main.cpp
+++ b/examples/rasta_grpc_bridge/cpp/main.cpp
@@ -147,8 +147,11 @@ void processConnection(std::function<std::thread()> run_thread) {
 
     close(s_data_fd[0]);
     close(s_data_fd[1]);
+    s_data_fd[0] = s_data_fd[1] = -1;
+    
     close(s_terminator_fd[0]);
     close(s_terminator_fd[1]);
+    s_terminator_fd[0] = s_terminator_fd[1] = -1;
 
     fifo_destroy(&s_message_fifo);
 }

--- a/examples/rasta_grpc_bridge/cpp/main.cpp
+++ b/examples/rasta_grpc_bridge/cpp/main.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <thread>
 
-#include <sys/eventfd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -53,7 +52,10 @@ void processConnection(std::function<std::thread()> run_thread) {
     s_message_fifo = fifo_init(128);
 
     // Data event
-    pipe(s_data_fd);
+    if (pipe(s_data_fd) < 0){
+        perror("Failed to create pipe");
+        abort();
+    }
     fd_event data_event;
     memset(&data_event, 0, sizeof(fd_event));
     data_event.callback = [](void *) {
@@ -85,7 +87,10 @@ void processConnection(std::function<std::thread()> run_thread) {
     add_fd_event(&s_rc->rasta_lib_event_system, &data_event, EV_READABLE);
 
     // Terminator event
-    pipe(s_terminator_fd);
+    if (pipe(s_terminator_fd) < 0){
+        perror("Failed to create pipe");
+        abort();
+    }
     fd_event terminator_event;
     memset(&terminator_event, 0, sizeof(fd_event));
     terminator_event.callback = [](void *carry) {


### PR DESCRIPTION
This replaces the `eventfd`s (Linux-specific) in the gRPC bridge by regular `pipe`s (POSIX standard). This makes the gRPC bridge compatible to other OSes such as MacOS or BSD and allows developers to use MacOS without a Devcontainer from now on.

This should hopefully close #41.