### PR TITLE
Replace recv_buf by fifo_receive to allow receiving multiple RaSTA packets at once

### DIFF
--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -580,6 +580,32 @@ void config_setstd(struct RastaConfig *cfg) {
     }
 
     /*
+     * Receive part
+     */
+
+    entr = config_get(cfg, "RASTA_RECVQUEUE_SIZE");
+    if (entr.type != DICTIONARY_NUMBER || entr.value.number < 0) {
+        // set std
+        cfg->values.receive.max_recvqueue_size = 20;
+    } else {
+        // check valid format
+        cfg->values.receive.max_recvqueue_size = (unsigned int)entr.value.number;
+    }
+
+    /*
+     * Retransmission part
+     */
+
+    entr = config_get(cfg, "RASTA_RETRANSMISSION_QUEUE_SIZE");
+    if (entr.type != DICTIONARY_NUMBER || entr.value.number < 0) {
+        // set std
+        cfg->values.retransmission.max_retransmission_queue_size = 100;
+    } else {
+        // check valid format
+        cfg->values.retransmission.max_retransmission_queue_size = (unsigned int)entr.value.number;
+    }
+
+    /*
      * Redundancy part
      */
 

--- a/examples/config/example_rasta_config.cfg
+++ b/examples/config/example_rasta_config.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client1.cfg
+++ b/examples/config/rasta_client1.cfg
@@ -61,6 +61,17 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
+
 ; configuration of the redundancy part
 
 ; A list of ip/port pairs that specify the network endpoints where the RaSTA entity will listen for messages (Redundancy channels)

--- a/examples/config/rasta_client1_local_kex.cfg
+++ b/examples/config/rasta_client1_local_kex.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client2.cfg
+++ b/examples/config/rasta_client2.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client2_local_dtls.cfg
+++ b/examples/config/rasta_client2_local_dtls.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client2_local_kex.cfg
+++ b/examples/config/rasta_client2_local_kex.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client2_local_tls.cfg
+++ b/examples/config/rasta_client2_local_tls.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client_local.cfg
+++ b/examples/config/rasta_client_local.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client_local_dtls.cfg
+++ b/examples/config/rasta_client_local_dtls.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_client_local_tls.cfg
+++ b/examples/config/rasta_client_local_tls.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_java.cfg
+++ b/examples/config/rasta_java.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_server.cfg
+++ b/examples/config/rasta_server.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_server_local.cfg
+++ b/examples/config/rasta_server_local.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_server_local_dtls.cfg
+++ b/examples/config/rasta_server_local_dtls.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_server_local_kex.cfg
+++ b/examples/config/rasta_server_local_kex.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_server_local_tls.cfg
+++ b/examples/config/rasta_server_local_tls.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/examples/config/rasta_wrapper.cfg
+++ b/examples/config/rasta_wrapper.cfg
@@ -61,6 +61,16 @@ RASTA_DIAG_WINDOW = 5000
 RASTA_INITIAL_SEQ = -1
 
 
+; configuration of the receive part
+
+;std: 20
+RASTA_RECVQUEUE_SIZE = 20
+
+; configuration of the retransmission part
+
+;std: 100
+RASTA_RETRANSMISSION_QUEUE_SIZE = 100
+
 
 ; configuration of the redundancy part
 

--- a/src/c/rasta_lib.c
+++ b/src/c/rasta_lib.c
@@ -123,10 +123,14 @@ void rasta_lib_init_configuration(rasta_lib_configuration_t user_configuration, 
         connection->receive_handle.hashing_context = &h->mux.sr_hashing_context;
 
         // init retransmission fifo
-        connection->fifo_retransmission = fifo_init(MAX_QUEUE_SIZE);
+        connection->fifo_retransmission = fifo_init(connection->config->retransmission.max_retransmission_queue_size);
 
         // create send queue
         connection->fifo_send = fifo_init(2 * connection->config->sending.max_packet);
+
+        // init receive queue
+        // TODO make capacity configurable by the user
+        connection->fifo_receive = fifo_init(connection->config->receive.max_recvqueue_size);
 
         init_connection_events(h, connection);
     }
@@ -139,6 +143,7 @@ void rasta_cleanup(rasta_lib_configuration_t user_configuration) {
     for (unsigned i = 0; i < user_configuration->h.rasta_connections_length; i++) {
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_retransmission);
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_send);
+        fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_receive);
     }
     rfree(user_configuration->h.rasta_connections);
 

--- a/src/c/rasta_lib.c
+++ b/src/c/rasta_lib.c
@@ -129,7 +129,6 @@ void rasta_lib_init_configuration(rasta_lib_configuration_t user_configuration, 
         connection->fifo_send = fifo_init(2 * connection->config->sending.max_packet);
 
         // init receive queue
-        // TODO make capacity configurable by the user
         connection->fifo_receive = fifo_init(connection->config->receive.max_recvqueue_size);
 
         init_connection_events(h, connection);

--- a/src/c/retransmission/safety_retransmission.h
+++ b/src/c/retransmission/safety_retransmission.h
@@ -27,7 +27,6 @@ int sr_message_authentic(struct rasta_connection *con, struct RastaPacket *packe
 int sr_check_packet(struct rasta_connection *con, struct logger_t *logger, rasta_config_sending *cfg, struct RastaPacket *receivedPacket, char *location);
 unsigned int sr_retransmission_queue_item_count(struct rasta_connection *connection);
 unsigned int sr_send_queue_item_count(struct rasta_connection *connection);
+unsigned int sr_recv_queue_item_count(struct rasta_connection *connection);
 int sr_receive(rasta_connection *con, struct RastaPacket *receivedPacket);
 void sr_closed_connection(rasta_connection *connection, unsigned long id);
-void sr_set_receive_buffer(void *buf, size_t len);
-size_t sr_get_received_data_len();

--- a/src/include/rasta/config.h
+++ b/src/include/rasta/config.h
@@ -34,6 +34,14 @@ typedef struct rasta_config_sending {
     rasta_hash_algorithm sr_hash_algorithm;
 } rasta_config_sending;
 
+typedef struct rasta_config_receive {
+    unsigned int max_recvqueue_size;
+} rasta_config_receive;
+
+typedef struct rasta_config_retransmission {
+    unsigned int max_retransmission_queue_size;
+} rasta_config_retransmission;
+
 /**
  * represents an IP and Port
  */
@@ -121,6 +129,14 @@ typedef struct rasta_config_info {
      * all values for the sending part
      */
     rasta_config_sending sending;
+    /**
+     * all values for the receive part
+     */
+    rasta_config_receive receive;
+    /**
+     * all values for the retransmission part
+     */
+    rasta_config_retransmission retransmission;
     /**
      * all values for the redundancy part
      */

--- a/src/include/rasta/rasta.h
+++ b/src/include/rasta/rasta.h
@@ -11,11 +11,6 @@ extern "C" { // only need to export C interface if
 #include "rastahandle.h"
 
 /**
- * size of ring buffer where data is hold for retransmissions
- */
-#define MAX_QUEUE_SIZE 100 // TODO: maybe in config file
-
-/**
  * the maximum length of application messages in the data of a RaSTA packet.
  * Length of a SCI PDU is max. 44 bytes
  */

--- a/src/include/rasta/temp.h
+++ b/src/include/rasta/temp.h
@@ -221,6 +221,11 @@ typedef struct rasta_connection {
     fifo_t *fifo_send;
 
     /**
+     * queue for received messages that have not yet been rasta_recv()'d
+    */
+    fifo_t *fifo_receive;
+
+    /**
      * the N_SENDMAX of the connection partner,  -1 if not connected
      */
     int connected_recv_buffer_size;

--- a/test/rasta_test/c/config_test.c
+++ b/test/rasta_test/c/config_test.c
@@ -36,6 +36,12 @@ void check_std_config() {
     CU_ASSERT_EQUAL(cfg.values.sending.max_packet, 3);
     CU_ASSERT_EQUAL(cfg.values.sending.diag_window, 5000);
 
+    // check receive
+    CU_ASSERT_EQUAL(cfg.values.receive.max_recvqueue_size, 20);
+
+    // check retransmission
+    CU_ASSERT_EQUAL(cfg.values.retransmission.max_retransmission_queue_size, 100);
+
     // check redundancy
     CU_ASSERT_EQUAL(cfg.values.redundancy.connections.count, 0);
     CU_ASSERT_EQUAL(cfg.values.redundancy.crc_type.width, 0);
@@ -62,6 +68,10 @@ void check_var_config() {
     fprintf(f, "RASTA_MWA = 15\n");
     fprintf(f, "RASTA_MAX_PACKET = 4\n");
     fprintf(f, "RASTA_DIAG_WINDOW = 6000\n");
+
+    fprintf(f, "RASTA_RECVQUEUE_SIZE = 42\n");
+
+    fprintf(f, "RASTA_RETRANSMISSION_QUEUE_SIZE = 50\n");
 
     fprintf(f, "RASTA_REDUNDANCY_CONNECTIONS = {\"192.168.2.1:8000\"; \"83.23.1.2:40\"}\n");
     fprintf(f, "RASTA_CRC_TYPE = TYPE_C\n");
@@ -95,9 +105,14 @@ void check_var_config() {
     CU_ASSERT_EQUAL(cfg.values.sending.max_packet, 4);
     CU_ASSERT_EQUAL(cfg.values.sending.diag_window, 6000);
 
+    // check receive
+    CU_ASSERT_EQUAL(cfg.values.receive.max_recvqueue_size, 42);
+
+    // check retransmission
+    CU_ASSERT_EQUAL(cfg.values.retransmission.max_retransmission_queue_size, 50);
+
     // check redundancy
     CU_ASSERT_EQUAL(cfg.values.redundancy.connections.count, 2);
-
     CU_ASSERT_EQUAL(strcmp(cfg.values.redundancy.connections.data[0].ip, "192.168.2.1"), 0);
     CU_ASSERT_EQUAL(cfg.values.redundancy.connections.data[0].port, 8000);
     CU_ASSERT_EQUAL(strcmp(cfg.values.redundancy.connections.data[1].ip, "83.23.1.2"), 0);

--- a/test/rasta_test/c/safety_retransmission_test.c
+++ b/test/rasta_test/c/safety_retransmission_test.c
@@ -39,6 +39,10 @@ void test_sr_retransmit_data_shouldSendFinalHeartbeat() {
     configInfoRedundancy.n_deferqueue_size = 2;
     info.redundancy = configInfoRedundancy;
 
+    rasta_config_retransmission configRetransmission;
+    configRetransmission.max_retransmission_queue_size = 100;
+    info.retransmission = configRetransmission;
+
     uint16_t listenPorts[1] = {1234};
     redundancy_mux mux = redundancy_mux_init(&logger, listenPorts, 1, &info);
     mux.sr_hashing_context.hash_length = RASTA_CHECKSUM_NONE;
@@ -63,6 +67,7 @@ void test_sr_retransmit_data_shouldSendFinalHeartbeat() {
     connection.remote_id = SERVER_ID;
     connection.fifo_retransmission = fifo_init(0);
     connection.redundancy_channel = &fake_channel;
+    connection.config = &info;
 
     sr_retransmit_data(&connection);
 
@@ -94,6 +99,10 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     configInfoRedundancy.n_deferqueue_size = 2;
     info.redundancy = configInfoRedundancy;
 
+    rasta_config_retransmission configRetransmission;
+    configRetransmission.max_retransmission_queue_size = 100;
+    info.retransmission = configRetransmission;
+
     uint16_t listenPorts[1] = {1234};
     redundancy_mux mux = redundancy_mux_init(&logger, listenPorts, 1, &info);
     mux.sr_hashing_context.hash_length = RASTA_CHECKSUM_NONE;
@@ -118,6 +127,7 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     connection.remote_id = SERVER_ID;
     connection.fifo_retransmission = fifo_init(1);
     connection.redundancy_channel = &fake_channel;
+    connection.config = &info;
 
     struct RastaMessageData app_messages;
     struct RastaByteArray message;


### PR DESCRIPTION
This fixes #46. Also, as I was already implementing configfile stuff, I made the capacity of `fifo_retransmission` configurable by the user.

@rs22: Does the default capacity of the receive queue make sense?