### PR TITLE
Directly send when space in retransmission queue becomes available

### DIFF
--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -96,9 +96,9 @@ int rasta_send(rasta_lib_configuration_t user_configuration, struct rasta_connec
     messageData1.data_array[0].bytes = buf;
     messageData1.data_array[0].length = len;
 
-    sr_send(&user_configuration->h, connection, messageData1);
+    int return_val = sr_send(&user_configuration->h, connection, messageData1);
     rfree(messageData1.data_array);
-    return 0;
+    return return_val;
 }
 
 void rasta_disconnect(struct rasta_connection *connection) {

--- a/src/c/retransmission/safety_retransmission.c
+++ b/src/c/retransmission/safety_retransmission.c
@@ -107,6 +107,11 @@ void sr_remove_confirmed_messages(struct rasta_connection *con) {
         freeRastaByteArray(&packet.data);
         rfree(elem);
     }
+
+    // sending is now possible again (space in the retransmission queue is available), so we should trigger it
+    if(fifo_full(con->fifo_send)){
+        data_send_event(&con->send_handle);
+    }
 }
 
 /* ----- processing of received packet types ----- */
@@ -361,6 +366,7 @@ void sr_listen(struct rasta_handle *h) {
     redundancy_mux_listen_channels(h, &h->mux, &h->config->tls);
 }
 
+// TODO make this method return an error code again, so the caller knows if sending went wrong
 void sr_send(struct rasta_handle *h, struct rasta_connection *con, struct RastaMessageData app_messages) {
     if (con == NULL)
         return;

--- a/src/c/retransmission/safety_retransmission.h
+++ b/src/c/retransmission/safety_retransmission.h
@@ -55,7 +55,7 @@ void sr_listen(struct rasta_handle *h);
  * @param con the connection to send the data on
  * @param app_messages the messages to send
  */
-void sr_send(struct rasta_handle *h, struct rasta_connection *con, struct RastaMessageData app_messages);
+int sr_send(struct rasta_handle *h, struct rasta_connection *con, struct RastaMessageData app_messages);
 
 /**
  * Handle a received packet on the safety/retransmission level and check validity

--- a/src/include/rasta/rasta_init.h
+++ b/src/include/rasta/rasta_init.h
@@ -8,11 +8,6 @@ extern "C" { // only need to export C interface if
 #include "logging.h"
 #include "rastahandle.h"
 
-/**
- * size of ring buffer where data is hold for retransmissions
- */
-#define MAX_QUEUE_SIZE 100 // TODO: maybe in config file
-
 #define DIAGNOSTIC_INTERVAL_SIZE 500
 
 typedef struct rasta_connection rasta_lib_connection_t[1];


### PR DESCRIPTION
This closes #40. One thing that should still be changed is returning an error code (0/-1 or 0/1 suffices) from `sr_send`, so `rasta_send` and thus the user knows when sending wasn't successful.