### PR TITLE
Re-try binding sockets

### DIFF
--- a/examples/rasta_grpc_bridge/cpp/main.cpp
+++ b/examples/rasta_grpc_bridge/cpp/main.cpp
@@ -152,7 +152,7 @@ void processConnection(std::function<std::thread()> run_thread) {
     close(s_data_fd[0]);
     close(s_data_fd[1]);
     s_data_fd[0] = s_data_fd[1] = -1;
-    
+
     close(s_terminator_fd[0]);
     close(s_terminator_fd[1]);
     s_terminator_fd[0] = s_terminator_fd[1] = -1;
@@ -191,7 +191,12 @@ void processRasta(std::string config_path,
     if (server) {
         memset(&s_rc, 0, sizeof(rasta_lib_configuration_t));
         rasta_lib_init_configuration(s_rc, &config, &logger, &connection, 1);
-        rasta_bind(s_rc);
+
+        if (rasta_bind(s_rc) == false) {
+            rasta_cleanup(s_rc);
+            return;
+        }
+
         rasta_listen(s_rc);
         while (true) {
             s_connection = rasta_accept(s_rc);
@@ -204,7 +209,12 @@ void processRasta(std::string config_path,
         while (true) {
             memset(&s_rc, 0, sizeof(rasta_lib_configuration_t));
             rasta_lib_init_configuration(s_rc, &config, &logger, &connection, 1);
-            rasta_bind(s_rc);
+
+            if (rasta_bind(s_rc) == false) {
+                rasta_cleanup(s_rc);
+                continue;
+            }
+
             s_connection = rasta_connect(s_rc, s_remote_id);
             if (s_connection) {
                 processConnection(run_thread);

--- a/examples/rasta_grpc_bridge/cpp/main.cpp
+++ b/examples/rasta_grpc_bridge/cpp/main.cpp
@@ -192,7 +192,7 @@ void processRasta(std::string config_path,
         memset(&s_rc, 0, sizeof(rasta_lib_configuration_t));
         rasta_lib_init_configuration(s_rc, &config, &logger, &connection, 1);
 
-        if (rasta_bind(s_rc) == false) {
+        if (!rasta_bind(s_rc)) {
             rasta_cleanup(s_rc);
             return;
         }
@@ -210,7 +210,7 @@ void processRasta(std::string config_path,
             memset(&s_rc, 0, sizeof(rasta_lib_configuration_t));
             rasta_lib_init_configuration(s_rc, &config, &logger, &connection, 1);
 
-            if (rasta_bind(s_rc) == false) {
+            if (!rasta_bind(s_rc)) {
                 rasta_cleanup(s_rc);
                 continue;
             }

--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -29,8 +29,8 @@ void log_main_loop_state(struct rasta_handle *h, event_system *ev_sys, const cha
                message, fd_event_active_count, fd_event_count, timed_event_active_count, timed_event_count);
 }
 
-void rasta_bind(rasta_lib_configuration_t user_configuration) {
-    redundancy_mux_bind(&user_configuration->h);
+bool rasta_bind(rasta_lib_configuration_t user_configuration) {
+    return redundancy_mux_bind(&user_configuration->h);
 }
 
 void rasta_listen(rasta_lib_configuration_t user_configuration) {
@@ -79,7 +79,7 @@ int rasta_recv(rasta_lib_configuration_t user_configuration, struct rasta_connec
     size_t received_len = (len < elem->length) ? len : elem->length;
 
     if (len < elem->length) {
-        logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA receive", 
+        logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA receive",
             "supplied buffer (%ld bytes) is smaller than message length (%d bytes) - received message may be incomplete!", len, elem->length);
     }
 

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -399,11 +399,12 @@ int redundancy_mux_connect_channel(rasta_connection *connection, redundancy_mux 
 void redundancy_mux_close_channel(rasta_redundancy_channel *c) {
     for (unsigned int i = 0; i < c->transport_channel_count; ++i) {
         rasta_transport_channel *channel = &c->transport_channels[i];
-        logger_log(c->mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux remove channel", "closing transport channel %u", i);
-        // if we are a client, the socket fd also becomes invalid when closing the channel
-        if(channel->file_descriptor == c->mux->transport_sockets[channel->id].file_descriptor) {
+        logger_log(c->mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux remove channel", "closing transport channel %u/%u", i, c->transport_channel_count);
+        int channel_fd = channel->file_descriptor;
+        transport_close(channel);
+        // if we are a TCP/TLS client (and transport_close actually closes the channel), the socket fd also becomes invalid
+        if(!channel->connected && channel_fd == c->mux->transport_sockets[channel->id].file_descriptor) {
             c->mux->transport_sockets[channel->id].file_descriptor = -1;
         }
-        transport_close(channel);
     }
 }

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -399,7 +399,7 @@ int redundancy_mux_connect_channel(rasta_connection *connection, redundancy_mux 
 void redundancy_mux_close_channel(rasta_redundancy_channel *c) {
     for (unsigned int i = 0; i < c->transport_channel_count; ++i) {
         rasta_transport_channel *channel = &c->transport_channels[i];
-        logger_log(c->mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux remove channel", "closing transport channel %u/%u", i, c->transport_channel_count);
+        logger_log(c->mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux remove channel", "closing transport channel %u/%u", i+1, c->transport_channel_count);
         int channel_fd = channel->file_descriptor;
         transport_close(channel);
         // if we are a TCP/TLS client (and transport_close actually closes the channel), the socket fd also becomes invalid

--- a/src/c/transport/bsd_utils.c
+++ b/src/c/transport/bsd_utils.c
@@ -58,24 +58,6 @@ int bsd_create_socket(int family, int type, int protocol_type) {
     return file_desc;
 }
 
-void bsd_bind_port(int file_descriptor, uint16_t port) {
-    struct sockaddr_in local;
-
-    // set struct to 0s
-    rmemset((char *)&local, 0, sizeof(local));
-
-    local.sin_family = AF_INET;
-    local.sin_port = htons(port);
-    local.sin_addr.s_addr = htonl(INADDR_ANY);
-
-    // bind socket to port
-    if (bind(file_descriptor, (struct sockaddr *)&local, sizeof(local)) < 0) {
-        // bind failed
-        fprintf(stderr, "could not bind the socket to port %d", port);
-        abort();
-    }
-}
-
 bool bsd_bind_device(int file_descriptor, uint16_t port, const char *ip) {
     struct sockaddr_in local = {0};
 

--- a/src/c/transport/bsd_utils.c
+++ b/src/c/transport/bsd_utils.c
@@ -42,13 +42,14 @@ int bsd_create_socket(int family, int type, int protocol_type) {
     }
 
     // Make socket reusable
-    if (setsockopt(file_desc, SOL_SOCKET, SO_REUSEADDR, &(int){1}, sizeof(int)) < 0) {
+    int one = 1;
+    if (setsockopt(file_desc, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int)) < 0) {
         perror("setsockopt(SO_REUSEADDR) failed");
         abort();
     }
 
 #ifdef SO_REUSEPORT
-    if (setsockopt(file_desc, SOL_SOCKET, SO_REUSEPORT, &(int){1}, sizeof(int)) < 0) {
+    if (setsockopt(file_desc, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(int)) < 0) {
         perror("setsockopt(SO_REUSEPORT) failed");
         abort();
     }
@@ -105,15 +106,8 @@ void bsd_send_sockaddr(int file_descriptor, unsigned char *message, size_t messa
 }
 
 void bsd_close(int file_descriptor) {
-    // close(file_descriptor);
     if (file_descriptor >= 0) {
-        getSO_ERROR(file_descriptor);                   // first clear any errors, which can cause close to fail
-        if (shutdown(file_descriptor, SHUT_RDWR) < 0)   // secondly, terminate the 'reliable' delivery
-            if (errno != ENOTCONN && errno != EINVAL) { // SGI causes EINVAL
-                perror("shutdown");
-                abort();
-            }
-        if (close(file_descriptor) < 0) // finally call close()
+        if (close(file_descriptor) < 0)
         {
             perror("close");
             abort();

--- a/src/c/transport/bsd_utils.c
+++ b/src/c/transport/bsd_utils.c
@@ -76,7 +76,7 @@ void bsd_bind_port(int file_descriptor, uint16_t port) {
     }
 }
 
-void bsd_bind_device(int file_descriptor, uint16_t port, const char *ip) {
+bool bsd_bind_device(int file_descriptor, uint16_t port, const char *ip) {
     struct sockaddr_in local = {0};
 
     local.sin_family = AF_INET;
@@ -86,9 +86,11 @@ void bsd_bind_device(int file_descriptor, uint16_t port, const char *ip) {
     // bind socket to port
     if (bind(file_descriptor, (struct sockaddr *)&local, sizeof(struct sockaddr_in)) < 0) {
         // bind failed
-        perror("could not bind the socket to port");
-        abort();
+        perror("bind");
+        return false;
     }
+
+    return true;
 }
 
 void bsd_send(int file_descriptor, unsigned char *message, size_t message_len, char *host, uint16_t port) {

--- a/src/c/transport/dtls.c
+++ b/src/c/transport/dtls.c
@@ -142,25 +142,6 @@ static void handle_tls_mode(rasta_transport_socket *transport_socket) {
     }
 }
 
-bool udp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
-    struct sockaddr_in local;
-
-    // set struct to 0s
-    rmemset((char *)&local, 0, sizeof(local));
-
-    local.sin_family = AF_INET;
-    local.sin_port = htons(port);
-    local.sin_addr.s_addr = htonl(INADDR_ANY);
-    // bind socket to port
-    if (bind(transport_socket->file_descriptor, (struct sockaddr *)&local, sizeof(local)) == -1) {
-        perror("bind");
-        return false;
-    }
-
-    handle_tls_mode(transport_socket);
-    return true;
-}
-
 bool udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
     struct sockaddr_in local;
 
@@ -323,9 +304,7 @@ void transport_listen(struct rasta_handle *h, rasta_transport_socket *socket) {
 }
 
 bool transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
-    UNUSED(ip);
-    
-    if (!udp_bind(socket, port)) {
+    if (!udp_bind_device(socket, ip, port)) {
         return false;
     }
 

--- a/src/c/transport/dtls.c
+++ b/src/c/transport/dtls.c
@@ -15,13 +15,9 @@
 
 #define MAX_WARNING_LENGTH_BYTES 128
 
-static void handle_port_unavailable(const uint16_t port) {
-    const char *warning_format = "could not bind the socket to port %d";
-    char warning_mbuf[MAX_WARNING_LENGTH_BYTES + 1];
-    snprintf(warning_mbuf, MAX_WARNING_LENGTH_BYTES, warning_format, port);
-
+static void handle_port_unavailable() {
     // bind failed
-    perror("warning_mbuf");
+    perror("bind");
     abort();
 }
 
@@ -163,7 +159,7 @@ void udp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
     local.sin_addr.s_addr = htonl(INADDR_ANY);
     // bind socket to port
     if (bind(transport_socket->file_descriptor, (struct sockaddr *)&local, sizeof(local)) == -1) {
-        handle_port_unavailable(port);
+        handle_port_unavailable();
     }
     handle_tls_mode(transport_socket);
 }

--- a/src/c/transport/tcp.c
+++ b/src/c/transport/tcp.c
@@ -19,8 +19,8 @@ void tcp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
     bsd_bind_port(transport_socket->file_descriptor, port);
 }
 
-void tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
-    bsd_bind_device(transport_socket->file_descriptor, port, ip);
+bool tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
+    return bsd_bind_device(transport_socket->file_descriptor, port, ip);
 }
 
 void tcp_listen(rasta_transport_socket *transport_socket) {
@@ -187,9 +187,9 @@ void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *soc
     add_fd_event(h->ev_sys, &socket->accept_event, EV_READABLE);
 }
 
-void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
+bool transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
     UNUSED(h);
-    tcp_bind_device(socket, ip, port);
+    return tcp_bind_device(socket, ip, port);
 }
 
 void transport_init(struct rasta_handle *h, rasta_transport_channel* channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config) {

--- a/src/c/transport/tcp.c
+++ b/src/c/transport/tcp.c
@@ -15,10 +15,6 @@ void tcp_init(rasta_transport_socket *transport_socket, const rasta_config_tls *
     transport_socket->file_descriptor = bsd_create_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 }
 
-void tcp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
-    bsd_bind_port(transport_socket->file_descriptor, port);
-}
-
 bool tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
     return bsd_bind_device(transport_socket->file_descriptor, port, ip);
 }

--- a/src/c/transport/tcp.c
+++ b/src/c/transport/tcp.c
@@ -149,6 +149,7 @@ int transport_redial(rasta_transport_channel* channel, rasta_transport_socket *s
 void transport_close(rasta_transport_channel *channel) {
     if (channel->connected) {
         bsd_close(channel->file_descriptor);
+        channel->file_descriptor = -1;
         channel->connected = false;
     }
 

--- a/src/c/transport/tcp.h
+++ b/src/c/transport/tcp.h
@@ -33,7 +33,7 @@ void tcp_listen(rasta_transport_socket *transport_socket);
  * @param ip the IPv4 address of the network interface the socket will listen on.
  * @param port the port the socket will listen on
  */
-void tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port);
+bool tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port);
 
 /**
  * Receive data on the given @p file descriptor and store it in the given buffer.

--- a/src/c/transport/tcp.h
+++ b/src/c/transport/tcp.h
@@ -15,13 +15,6 @@ typedef struct rasta_transport_channel rasta_transport_channel;
 void tcp_init(rasta_transport_socket *transport_socket, const rasta_config_tls *tls_config);
 
 /**
- * Binds a given file descriptor to the given @p port
- * @param file_descriptor the is the file descriptor which will be bound to to the @p port.
- * @param port the port the socket will listen on
- */
-void tcp_bind(rasta_transport_socket *transport_socket, uint16_t port);
-
-/**
  * Prepare to accept connections on the given @p file_descriptor.
  * @param file_descriptor the file descriptor to accept connections from
  */

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -350,6 +350,7 @@ int transport_redial(rasta_transport_channel* channel, rasta_transport_socket *s
 void transport_close(rasta_transport_channel *channel) {
     if (channel->connected) {
         bsd_close(channel->file_descriptor);
+        channel->file_descriptor = -1;
         if (channel->ssl) {
             wolfSSL_shutdown(channel->ssl);
             wolfSSL_free(channel->ssl);

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -141,8 +141,8 @@ void tcp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
     bsd_bind_port(transport_socket->file_descriptor, port);
 }
 
-void tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
-    bsd_bind_device(transport_socket->file_descriptor, port, ip);
+bool tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
+    return bsd_bind_device(transport_socket->file_descriptor, port, ip);
 }
 
 void tcp_listen(rasta_transport_socket *transport_socket) {

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -137,10 +137,6 @@ static void handle_tls_mode_client(rasta_transport_channel *transport_channel) {
     }
 }
 
-void tcp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
-    bsd_bind_port(transport_socket->file_descriptor, port);
-}
-
 bool tcp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
     return bsd_bind_device(transport_socket->file_descriptor, port, ip);
 }

--- a/src/c/transport/tls.c
+++ b/src/c/transport/tls.c
@@ -343,7 +343,7 @@ int transport_redial(rasta_transport_channel* channel, rasta_transport_socket *s
 
     socket->receive_event.fd = socket->file_descriptor;
     socket->accept_event.fd = socket->file_descriptor;
-    
+
     return 0;
 }
 
@@ -391,9 +391,9 @@ void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *soc
     add_fd_event(h->ev_sys, &socket->accept_event, EV_READABLE);
 }
 
-void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
+bool transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
     UNUSED(h);
-    tcp_bind_device(socket, ip, port);
+    return tcp_bind_device(socket, ip, port);
 }
 
 void transport_init(struct rasta_handle *h, rasta_transport_channel* channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config) {

--- a/src/c/transport/transport.h
+++ b/src/c/transport/transport.h
@@ -97,7 +97,7 @@ ssize_t receive_callback(struct receive_event_data *data, unsigned char *buffer,
 
 void transport_init(struct rasta_handle *h, rasta_transport_channel *channel, unsigned id, const char *host, uint16_t port, const rasta_config_tls *tls_config);
 void transport_create_socket(struct rasta_handle *h, rasta_transport_socket *socket, int id, const rasta_config_tls *tls_config);
-void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port);
+bool transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port);
 void transport_listen(struct rasta_handle *h, rasta_transport_socket *socket);
 int transport_accept(rasta_transport_socket *socket, struct sockaddr_in *addr);
 int transport_connect(rasta_transport_socket *socket, rasta_transport_channel *channel, rasta_config_tls tls_config);

--- a/src/c/transport/udp.c
+++ b/src/c/transport/udp.c
@@ -29,24 +29,6 @@ static void handle_tls_mode(rasta_transport_socket *transport_socket) {
     }
 }
 
-bool udp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
-    struct sockaddr_in local;
-    rmemset((char *)&local, 0, sizeof(local));
-
-    local.sin_family = AF_INET;
-    local.sin_port = htons(port);
-    local.sin_addr.s_addr = htonl(INADDR_ANY);
-
-    // bind socket to port
-    if (bind(transport_socket->file_descriptor, (struct sockaddr *)&local, sizeof(local)) == -1) {
-        // bind failed
-        perror("bind");
-        return false;
-    }
-    handle_tls_mode(transport_socket);
-    return true;
-}
-
 bool udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
     struct sockaddr_in local = {0};
 

--- a/src/c/transport/udp.c
+++ b/src/c/transport/udp.c
@@ -15,16 +15,6 @@
 
 #define MAX_WARNING_LENGTH_BYTES 128
 
-static void handle_port_unavailable(const uint16_t port) {
-    const char *warning_format = "could not bind the socket to port %d";
-    char warning_mbuf[MAX_WARNING_LENGTH_BYTES + 1];
-    snprintf(warning_mbuf, MAX_WARNING_LENGTH_BYTES, warning_format, port);
-
-    // bind failed
-    perror("warning_mbuf");
-    abort();
-}
-
 static void handle_tls_mode(rasta_transport_socket *transport_socket) {
     const rasta_config_tls *tls_config = transport_socket->tls_config;
     switch (tls_config->mode) {
@@ -39,7 +29,7 @@ static void handle_tls_mode(rasta_transport_socket *transport_socket) {
     }
 }
 
-void udp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
+bool udp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
     struct sockaddr_in local;
     rmemset((char *)&local, 0, sizeof(local));
 
@@ -49,12 +39,15 @@ void udp_bind(rasta_transport_socket *transport_socket, uint16_t port) {
 
     // bind socket to port
     if (bind(transport_socket->file_descriptor, (struct sockaddr *)&local, sizeof(local)) == -1) {
-        handle_port_unavailable(port);
+        // bind failed
+        perror("bind");
+        return false;
     }
     handle_tls_mode(transport_socket);
+    return true;
 }
 
-void udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
+bool udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port) {
     struct sockaddr_in local = {0};
 
     local.sin_family = AF_INET;
@@ -64,11 +57,12 @@ void udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, u
     // bind socket to port
     if (bind(transport_socket->file_descriptor, (struct sockaddr *)&local, sizeof(struct sockaddr_in)) == -1) {
         // bind failed
-        handle_port_unavailable(port);
-        abort();
+        perror("bind");
+        return false;
     }
 
     handle_tls_mode(transport_socket);
+    return true;
 }
 
 void udp_close(rasta_transport_socket *transport_socket) {
@@ -197,9 +191,9 @@ void transport_listen(struct rasta_handle *h, rasta_transport_socket *socket) {
     enable_fd_event(&socket->receive_event);
 }
 
-void transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
+bool transport_bind(struct rasta_handle *h, rasta_transport_socket *socket, const char *ip, uint16_t port) {
     UNUSED(h);
-    udp_bind_device(socket, ip, port);
+    return udp_bind_device(socket, ip, port);
 }
 
 int transport_accept(rasta_transport_socket *socket, struct sockaddr_in *addr) {

--- a/src/c/transport/udp.h
+++ b/src/c/transport/udp.h
@@ -31,7 +31,7 @@ void udp_init(rasta_transport_socket *transport_socket, const rasta_config_tls *
  * @param transport_socket transport_socket with the file descriptor which will be bound to to the @p port.
  * @param port the port the socket will listen on
  */
-void udp_bind(rasta_transport_socket *transport_socket, uint16_t port);
+bool udp_bind(rasta_transport_socket *transport_socket, uint16_t port);
 
 /**
  * Binds a given file descriptor to the given @p port at the network interface with IPv4 address @p ip
@@ -39,7 +39,7 @@ void udp_bind(rasta_transport_socket *transport_socket, uint16_t port);
  * @param port the port the socket will listen on
  * @param ip the IPv4 address of the network interface the socket will listen on.
  */
-void udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port);
+bool udp_bind_device(rasta_transport_socket *transport_socket, const char *ip, uint16_t port);
 
 /**
  * Receive data on the given @p file descriptor and store it in the given buffer.

--- a/src/c/transport/udp.h
+++ b/src/c/transport/udp.h
@@ -27,13 +27,6 @@ extern "C" { // only need to export C interface if
 void udp_init(rasta_transport_socket *transport_socket, const rasta_config_tls *tls_config);
 
 /**
- * Binds a given file descriptor to the given @p port
- * @param transport_socket transport_socket with the file descriptor which will be bound to to the @p port.
- * @param port the port the socket will listen on
- */
-bool udp_bind(rasta_transport_socket *transport_socket, uint16_t port);
-
-/**
  * Binds a given file descriptor to the given @p port at the network interface with IPv4 address @p ip
  * @param transport_socket transport_socket with the file descriptor which will be bound to to the @p port.
  * @param port the port the socket will listen on

--- a/src/include/rasta/bsd_utils.h
+++ b/src/include/rasta/bsd_utils.h
@@ -1,4 +1,6 @@
+#include <stdbool.h>
 #include <arpa/inet.h>
+
 #define IPV4_STR_LEN 16
 
 /**
@@ -21,7 +23,7 @@ void bsd_bind_port(int file_descriptor, uint16_t port);
  * @param port the port the socket will listen on
  * @param ip the IPv4 address of the network interface the socket will listen on.
  */
-void bsd_bind_device(int file_descriptor, uint16_t port, const char *ip);
+bool bsd_bind_device(int file_descriptor, uint16_t port, const char *ip);
 
 /**
  * Sends a message via the given file descriptor to a @p host and @p port

--- a/src/include/rasta/rasta.h
+++ b/src/include/rasta/rasta.h
@@ -22,7 +22,7 @@ void log_main_loop_state(struct rasta_handle *h, event_system *ev_sys, const cha
  * binds a RaSTA instance to the configured IP addresses and ports for the transport channels
  * @param user_configuration the user configuration to be used
  */
-void rasta_bind(rasta_lib_configuration_t user_configuration);
+bool rasta_bind(rasta_lib_configuration_t user_configuration);
 
 /**
  * Listen on all sockets specified by the given RaSTA handle.

--- a/src/include/rasta/rasta_red_multiplexer.h
+++ b/src/include/rasta/rasta_red_multiplexer.h
@@ -153,7 +153,7 @@ void redundancy_mux_init_config(redundancy_mux *mux, struct logger_t *logger, ra
  * binds all transport sockets of a redundancy layer multiplexer to their respective IP/port
  * @param h the RaSTA handle containing the multiplexer
 */
-void redundancy_mux_bind(struct rasta_handle *h);
+bool redundancy_mux_bind(struct rasta_handle *h);
 
 /**
  * stops the redundancy layer multiplexer and closes all redundancy channels before cleaning up memory


### PR DESCRIPTION
My problem is the following:

I run the rasta_grpc_bridge_udp in RaSTA client mode and in gRPC server mode.

It will attempt one connection request and afterwards abort() with the mis-leading error message `warning_mbuf: Address already in use` (the reason is that udp bind() fails, has nothing to do with mbuf)

 - Instead of calling `abort()`, we should communicate the problem to the API user
 - I have thus changed the return type of rasta_bind (do we already have a convention how errors are reported? I'm using a boolean return value)
 - The root problem (address already in use) can be mitigated *for a certain period of time*, by actually closing the old udp transport socket (see the diff). Haven't tested the consequences for TCP/TLS. Why did we comment out that `bsd_close` call in the first place?
 - After some time however, the issue faces nontheless and because of my re-try logic, we're now stuck in an endless busy-loop of failing bind-calls

Why didn't we have this problem before?

I wish we had some structured tests for this...